### PR TITLE
Create a Workflow To Check PR Base

### DIFF
--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -1,0 +1,27 @@
+name: Check PR Base
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - 'dev'
+
+jobs:
+  check-pr-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check if PR is based on latest main
+        run: |
+          git fetch origin main:main
+          if git merge-base --is-ancestor origin/main ${{ github.event.pull_request.head.sha }}; then
+            echo "The PR is based on the latest main."
+          else
+            echo "The PR is not based on the latest main."
+            echo "You need rebase/merge."
+            exit 1
+          fi

--- a/.github/workflows/pirc.yml
+++ b/.github/workflows/pirc.yml
@@ -8,6 +8,7 @@ on:
     types: [opened, synchronize, closed]
     branches:
       - 'main'
+      - 'dev'
     paths-ignore:
       - '.githooks/**'
       - '**/LICENSE'
@@ -16,6 +17,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'dev'
     paths-ignore:
       - '.githooks/**'
       - '**/LICENSE'


### PR DESCRIPTION
Due to the regulations of the ELR course, there should be no merge conflicts when merging `dev` into `main`. Therefore, a rule has been enforced here that requires all PRs targeting at `dev` to be based on the latest `main`.
