### PR TITLE
Fixed TVar issue in Dot/fixed pretty print not compiling

### DIFF
--- a/lib/ast_utils/dot_ast.ml
+++ b/lib/ast_utils/dot_ast.ml
@@ -65,6 +65,8 @@ let rec dot_local_type (string_of_info : 'a -> string) (typ : 'a Local.typ)
     spf "%s [label=\"String %s\"];\n" node_name (string_of_info info), node_name
   | TBool info ->
     spf "%s [label=\"Bool %s\"];\n" node_name (string_of_info info), node_name
+  | TVar (TypId (id, _), info) ->
+    spf "%s [label=\"TVar %s %s\"];\n" node_name id (string_of_info info), node_name
   | TProd (typ1, typ2, info) ->
     let c1, n1 = dot_local_type string_of_info typ1 in
     let c2, n2 = dot_local_type string_of_info typ2 in
@@ -269,6 +271,8 @@ let rec dot_choreo_type (string_of_info : 'a -> string) (typ : 'a Choreo.typ)
     let c, n = dot_local_type string_of_info typ in
     let edge = spf "%s -> %s;\n" node_name n in
     locid_node ^ edge ^ c, node_name
+  | TVar (Typ_Id (id, _), info) ->
+    spf "%s [label=\"TVar %s %s\"];\n" node_name id (string_of_info info), node_name
   | TMap (typ1, typ2, info) ->
     let c1, n1 = dot_choreo_type string_of_info typ1 in
     let c2, n2 = dot_choreo_type string_of_info typ2 in
@@ -392,12 +396,13 @@ and dot_stmt (string_of_info : 'a -> string) (stmt : 'a Choreo.stmt) : string * 
     var_node ^ edge ^ c, node_name
   | ForeignDecl (VarId (id, _), typ, s, info) ->
     let node_name = generate_node_name () in
-    let decl_node = 
-      spf "%s [label=\"ForeignDecl: %s -> %s %s\"];\n" 
-        node_name 
-        id 
+    let decl_node =
+      spf
+        "%s [label=\"ForeignDecl: %s -> %s %s\"];\n"
+        node_name
+        id
         s
-        (string_of_info info) 
+        (string_of_info info)
     in
     let c, n = dot_choreo_type string_of_info typ in
     let edge = spf "%s -> %s;\n" node_name n in

--- a/test/prettyprint_test.ml
+++ b/test/prettyprint_test.ml
@@ -30,7 +30,7 @@ let suite =
               ; ("local_pat_match_2" >:: fun _ -> peq Astutils_testcases.lcl_pat_match_2)
               ]
        ; "Foreign Declarations"
-         >::: [ ("foreign_decl" >:: fun _ -> peq Testcases.foreign_decl) ]
+         >::: [ ("foreign_decl" >:: fun _ -> peq Astutils_testcases.foreign_decl) ]
        ]
 ;;
 


### PR DESCRIPTION
Dune wouldn't build, so there had to be some fixes for TVar issue in the DOT generator, and also the pretty print needed a fix in one of the lines.

emit_core.ml is just formatted to look prettier, no content changed.