### PR TITLE
Added back toplevel-shm test module in test/dune

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -110,3 +110,10 @@
  (libraries ounit2 ppxlib ast_core codegen)
  (preprocess
   (pps ppxlib.metaquot)))
+
+(test
+ (name toplevel_shm_test)
+ (modules toplevel_shm_test)
+ (libraries ounit2 ppxlib ast_core codegen)
+ (preprocess
+  (pps ppxlib.metaquot)))


### PR DESCRIPTION
Unsure where, but the toplevel-shm's testing module was deleted. It has now been added back to allow full testings of the code generation.