### PR TITLE
pprint_ast.ml now correctly prints "send {e} ~> {loc_id}" and "recv from {loc_id}"

### DIFF
--- a/lib/ast_utils/pprint_ast.ml
+++ b/lib/ast_utils/pprint_ast.ml
@@ -322,8 +322,8 @@ and pprint_net_expr ppf (expr : 'a Net.expr) =
   | Snd (e, _) -> fprintf ppf "@[<hv2>snd %a@]" pprint_net_expr e
   | Left (e, _) -> fprintf ppf "@[<hv2>left %a@]" pprint_net_expr e
   | Right (e, _) -> fprintf ppf "@[<hv2>right %a@]" pprint_net_expr e
-  | Send (e, LocId (loc, _), _) -> fprintf ppf "@[<hv2>%a ~> %s@]" pprint_net_expr e loc
-  | Recv (LocId (loc, _), _) -> fprintf ppf "@[<~ %s@]" loc
+  | Send (e, LocId (loc, _), _) -> fprintf ppf "@[<hv2>send %a ~> %s@]" pprint_net_expr e loc
+  | Recv (LocId (loc, _), _) -> fprintf ppf "@[recv from %s@]" loc
   | If (e1, e2, e3, _) ->
     fprintf
       ppf

--- a/test/astutils_testcases.ml
+++ b/test/astutils_testcases.ml
@@ -95,3 +95,16 @@ let netir_ex3 =
   \      | L -> ret (5)\n\
   \      | R -> ret (9);\n"
 ;;
+
+
+let netir_ex6_audvy =
+  "\n\
+  main := let _ := send ret 3 ~> R; in allow choice from R with\n\
+  \                                    | R -> ret \"Bye\"\n\
+  \                                    | L -> ret \"Hello\";\n"
+
+  let netir_ex7_audvy =
+  "\n\
+  main := let x := recv from S; in if ret x > 5 then choose L for S in unit else \n\
+  \                               choose R for S in unit;\n"
+  

--- a/test/prettyprint_test.ml
+++ b/test/prettyprint_test.ml
@@ -74,6 +74,8 @@ let suite =
        ; "Net IR"
          >::: [ ("simple_net" >:: fun _ -> net_peq Astutils_testcases.simple_net)
               ; ("ex3_netir" >:: fun _ -> net_peq Astutils_testcases.netir_ex3)
+              ; ("netir_ex6_audvy" >:: fun _ -> net_peq Astutils_testcases.netir_ex6_audvy)
+              ; ("netir_ex7_audvy" >:: fun _ -> net_peq Astutils_testcases.netir_ex7_audvy)
               ]
        ]
 ;;


### PR DESCRIPTION
Added testcases in astutils_testcases.ml and prettyprint_test.ml that add test coverage to the pprint_asl.ml lines for pretty printing NetIR "send" and "recv from" tokens. Bisect reports both lines in pprint_ast.ml as being green covered.